### PR TITLE
Fixed the use of the default route

### DIFF
--- a/src/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Traits/LoadsTranslatedCachedRoutes.php
@@ -26,14 +26,16 @@ trait LoadsTranslatedCachedRoutes
 
         $locale = $localization->getCurrentLocale();
 
+        $localeKeys = $localization->getSupportedLanguagesKeys();
+
         // First, try to load the routes specifically cached for this locale
         // if they do not exist, write a warning to the log and load the default
         // routes instead. Note that this is guaranteed to exist, becaused the
         // 'cached routes' check in the Application checks its existence.
 
-        $path = $this->makeLocaleRoutesPath($locale);
+        $path = $this->makeLocaleRoutesPath($locale, $localeKeys);
 
-        if ( ! file_exists($path)) {
+        if ( ! file_exists($path) ) {
 
             Log::warning("Routes cached, but no cached routes found for locale '{$locale}'!");
 
@@ -49,11 +51,16 @@ trait LoadsTranslatedCachedRoutes
      * Returns the path to the cached routes file for a given locale.
      *
      * @param string $locale
+     * @param array $localeKeys
      * @return string
      */
-    protected function makeLocaleRoutesPath($locale)
+    protected function makeLocaleRoutesPath($locale, $localeKeys)
     {
         $path = $this->getDefaultCachedRoutePath();
+
+        if ( ! in_array( $this->getFirstWordOfRequestUrl(), $localeKeys ) ) {
+            return $path;
+        }
 
         return substr($path, 0, -4) . '_' . $locale . '.php';
     }
@@ -74,6 +81,19 @@ trait LoadsTranslatedCachedRoutes
     protected function getLaravelLocalization()
     {
         return app('laravellocalization');
+    }
+
+    /**
+     * Get current url path first word
+     * \Illuminate\Http\Request
+     *
+     * @return string
+     */
+    protected function getFirstWordOfRequestUrl()
+    {
+        $uri = app('request')->path();
+
+        return substr($uri, 0, 2);
     }
 
 }

--- a/src/Traits/TranslatedRouteCommandContext.php
+++ b/src/Traits/TranslatedRouteCommandContext.php
@@ -47,11 +47,14 @@ trait TranslatedRouteCommandContext
      * @param string $locale
      * @return string
      */
-    protected function makeLocaleRoutesPath($locale)
+    protected function makeLocaleRoutesPath($locale = '')
     {
         $path = $this->laravel->getCachedRoutesPath();
 
+        if ( ! $locale ) {
+            return $path;
+        }
+
         return substr($path, 0, -4) . '_' . $locale . '.php';
     }
-
 }


### PR DESCRIPTION
It's a great Laravel package, but I did realise some problem when I use it. I realised that when I visit `/auth/login` rather than `/zh/auth/login`, i will not be led to the corresponding link. This issue has already been solved by the **PR**.   

I had a look at your code, and realised that you generate route through default rather than through system's way. Also, in terms of the loading of route cache, I realised that if i do not insert language tag, the package will not be loaded to the default route `bootstrap/cahce/routes.php`. I have also made some adjustment according to this issue, in order to let the route perform better.

Personally i think route cache should apply the default way under default situation. If you also agree, please accept my request. Thank you.