### PR TITLE
Set locale not only for Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "czim/laravel-localization-route-cache",
+    "name": "xaoc/laravel-localization-route-cache",
     "description": "Translated route caching solution for laravel localization",
     "keywords": [
         "localization",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "xaoc/laravel-localization-route-cache",
+    "name": "czim/laravel-localization-route-cache",
     "description": "Translated route caching solution for laravel localization",
     "keywords": [
         "localization",

--- a/src/LaravelLocalization.php
+++ b/src/LaravelLocalization.php
@@ -52,7 +52,7 @@ class LaravelLocalization extends McamaraLaravelLocalization
 
         $this->app->setLocale($this->currentLocale);
 
-        if (preg_match('#^5\.2\.#', Application::VERSION)) {
+        if (preg_match('#^5\.[2-9]\.#', Application::VERSION)) {
             // Regional locale such as de_DE, so formatLocalized works in Carbon
             $regional = $this->getCurrentLocaleRegional();
 


### PR DESCRIPTION
It's not very clear why there is a restriction with Laravel 5.2.
Now it will work with Laravel 5.2 and higher

P.S. To be frankly I don't any reason to keep this condition, maybe would be better to drop it?