### PR TITLE
Locale segment failure after commit 55ea1fd54aef044c83388148108c36858…

### DIFF
--- a/src/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Traits/LoadsTranslatedCachedRoutes.php
@@ -59,7 +59,7 @@ trait LoadsTranslatedCachedRoutes
         $path = $this->getDefaultCachedRoutePath();
 
         $localeSegment = request()->segment(1);
-        if ($localeSegment && ! in_array($localeSegment, $localeKeys)) {
+        if (!$localeSegment || ! in_array($localeSegment, $localeKeys)) {
             return $path;
         }
 

--- a/src/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Traits/LoadsTranslatedCachedRoutes.php
@@ -59,7 +59,7 @@ trait LoadsTranslatedCachedRoutes
         $path = $this->getDefaultCachedRoutePath();
 
         $localeSegment = request()->segment(1);
-        if (!$localeSegment || ! in_array($localeSegment, $localeKeys)) {
+        if ( ! $localeSegment || ! in_array($localeSegment, $localeKeys)) {
             return $path;
         }
 


### PR DESCRIPTION
After this commit, https://github.com/czim/laravel-localization-route-cache/commit/55ea1fd54aef044c83388148108c3685850658fb
Our production server was down on the start page (/), because if $localeSegment is empty makeLocaleRoutesPath returns routes_en.php instead of routes.php